### PR TITLE
Fix for windows

### DIFF
--- a/template/webpack.config.js
+++ b/template/webpack.config.js
@@ -44,7 +44,9 @@ module.exports = (env, argv) => {
             if (instance) {
               return;
             }
-            instance = spawn("npm", ["run", "webpackRun"]);
+            instance = spawn("npm", ["run", "webpackRun"], {
+							shell: true
+						});
             instance.stdout.on("data", function(data) {
               console.log(data.toString());
             });


### PR DESCRIPTION
Added a fix so `npm run dev` runs on Windows. I think this is because `npm` is not an executable on windows, but in a shell environment it is. I think it should still work fine on Linux. Perhaps you can confirm? For more info see https://github.com/nodejs/node/issues/3675