### PR TITLE
Update webpack.config.js

### DIFF
--- a/template/webpack.config.js
+++ b/template/webpack.config.js
@@ -66,7 +66,7 @@ module.exports = (env, argv) => {
     },
     externals: [
       nodeExternals({
-        whitelist: ["webpack/hot/dev-server", "webpack/hot/poll?100"]
+        allowlist: ["webpack/hot/dev-server", "webpack/hot/poll?100"]
       })
     ]
   };


### PR DESCRIPTION
When running the following command:
```
npm run dev
```

The following error is thrown:
```
> wallpaper-ui@0.0.1 dev
> webpack --mode=development

[webpack-cli] Error: [webpack-node-externals] : Option 'whitelist' is not supported. Did you mean 'allowlist'?
    at Object.exports.error (/home/razvan/dev/wallpaper-ui/node_modules/webpack-node-externals/utils.js:139:11)
    at /home/razvan/dev/wallpaper-ui/node_modules/webpack-node-externals/index.js:29:19
    at Array.forEach (<anonymous>)
    at nodeExternals (/home/razvan/dev/wallpaper-ui/node_modules/webpack-node-externals/index.js:28:18)
    at module.exports (/home/razvan/dev/wallpaper-ui/webpack.config.js:68:7)
    at loadConfigByPath (/home/razvan/dev/wallpaper-ui/node_modules/webpack-cli/lib/webpack-cli.js:1439:37)
    at async WebpackCLI.loadConfig (/home/razvan/dev/wallpaper-ui/node_modules/webpack-cli/lib/webpack-cli.js:1510:38)
    at async WebpackCLI.createCompiler (/home/razvan/dev/wallpaper-ui/node_modules/webpack-cli/lib/webpack-cli.js:1785:22)
    at async WebpackCLI.runWebpack (/home/razvan/dev/wallpaper-ui/node_modules/webpack-cli/lib/webpack-cli.js:1890:20)
    at async Command.<anonymous> (/home/razvan/dev/wallpaper-ui/node_modules/webpack-cli/lib/webpack-cli.js:912:21)
```
Webpack has changed its "whitelist" propriety to "allowlist".